### PR TITLE
Don't shut down process pool if it never started.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Packages
 *.egg
 *.egg-info
+*.eggs
 dist
 build
 eggs
@@ -37,3 +38,5 @@ nosetests.xml
 # PyCharm
 .idea
 
+# venv
+.venv

--- a/firebase/__init__.py
+++ b/firebase/__init__.py
@@ -1,6 +1,6 @@
 import atexit
 
-from ._async import process_pool
+from ._async import process_pool, _process_pool
 from .firebase import *
 
 
@@ -10,6 +10,8 @@ def close_process_pool():
     Clean up function that closes and terminates the process pool
     defined in the ``async`` file.
     """
-    process_pool.close()
-    process_pool.join()
-    process_pool.terminate()
+    # if the pool doesn't already exist, don't create it just to stop it.
+    if _process_pool is not None:
+        process_pool.close()
+        process_pool.join()
+        process_pool.terminate()


### PR DESCRIPTION
When running scripts that `import cambly` but don't trigger any `firebase` interactions, we get exactly 5 of these weird `multiprocessing` errors:
```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/pool.py", line 212, in __init__
    self._repopulate_pool()
  File "/Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/pool.py", line 303, in _repopulate_pool
    return self._repopulate_pool_static(self._ctx, self.Process,
  File "/Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/pool.py", line 326, in _repopulate_pool_static
    w.start()
  File "/Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/process.py", line 118, in start
    assert not _current_process._config.get('daemon'), \
AssertionError: daemonic processes are not allowed to have children
```
The root issue is `firebase` is trying to shutdown at the end of the process when it never started in the first place.

We can hack a fix by just checking if the underlying global has been set yet.

For context, I ran into this while trying to make [`smartling/translate.py`](https://github.com/Cambly/Cambly-Backend/blob/c147d36e08bb7413a10ba461275be3d4f0477eda/smartling/translate.py) use `cambly.localization`, when it had never imported `cambly` before. Importing `cambly` imports `firebase`, but the script somehow avoids ever making a `firebase` call. So every run of `smartling.sh request_translations` was printing those `multiprocessing` tracebacks at the end.

## Open Dependencies
N/A

## Testing
- Ran unit tests:
  ```
  $ python setup.py test
  running test
  WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
  WARNING: The wheel package is not available.
  WARNING: The wheel package is not available.
  WARNING: The wheel package is not available.
  WARNING: The wheel package is not available.
  running egg_info
  writing python_firebase.egg-info/PKG-INFO
  writing dependency_links to python_firebase.egg-info/dependency_links.txt
  writing requirements to python_firebase.egg-info/requires.txt
  writing top-level names to python_firebase.egg-info/top_level.txt
  reading manifest file 'python_firebase.egg-info/SOURCES.txt'
  adding license file 'LICENSE'
  writing manifest file 'python_firebase.egg-info/SOURCES.txt'
  running build_ext
  test_conversion (tests.jsonutil_test.JSONTestCase) ... ok
  test_total_seconds (tests.jsonutil_test.JSONTestCase) ... ok
  test_build_endpoint_url (tests.firebase_test.FirebaseTestCase) ... ok
  test_make_delete_request (tests.firebase_test.FirebaseTestCase) ... ok
  test_make_get_request (tests.firebase_test.FirebaseTestCase) ... ok
  test_make_patch_request (tests.firebase_test.FirebaseTestCase) ... ok
  test_make_post_request (tests.firebase_test.FirebaseTestCase) ... ok
  test_make_put_request (tests.firebase_test.FirebaseTestCase) ... ok

  ----------------------------------------------------------------------
  Ran 8 tests in 0.001s

  OK
  ```
- Installed local package and ran test script:
  - Setup:
    ```
    $ echo 'import firebase' > test_firebase_import_and_dont_use.py

    $ python -m venv .venv

    $ source .venv/bin/activate

    (.venv) $ pip install -e .
    Obtaining file:///Users/alex/cambly/python-firebase
      Preparing metadata (setup.py) ... done
    Collecting requests>=1.1.0
      Using cached requests-2.32.3-py3-none-any.whl (64 kB)
    Collecting certifi>=2017.4.17
      Downloading certifi-2024.7.4-py3-none-any.whl (162 kB)
         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 163.0/163.0 KB 2.6 MB/s eta 0:00:00
    Collecting idna<4,>=2.5
      Using cached idna-3.7-py3-none-any.whl (66 kB)
    Collecting charset-normalizer<4,>=2
      Using cached charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl (122 kB)
    Collecting urllib3<3,>=1.21.1
      Using cached urllib3-2.2.2-py3-none-any.whl (121 kB)
    Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests, python-firebase
      Running setup.py develop for python-firebase
    Successfully installed certifi-2024.7.4 charset-normalizer-3.3.2 idna-3.7 python-firebase-1.2 requests-2.32.3 urllib3-2.2.2
    WARNING: You are using pip version 22.0.4; however, version 24.1.2 is available.
    You should consider upgrading via the '/Users/alex/cambly/python-firebase/.venv/bin/python -m pip install --upgrade pip' command.
    ```
  - Before fix, test script printed multiprocessing errors and warned of leaked objects:
    ```
    (.venv) $ python -m test_firebase_import_and_dont_use
    Error in atexit._run_exitfuncs:
    Traceback (most recent call last):
      File "/Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/pool.py", line 212, in __init__
        self._repopulate_pool()
      File "/Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/pool.py", line 303, in _repopulate_pool
        return self._repopulate_pool_static(self._ctx, self.Process,
      File "/Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/pool.py", line 326, in _repopulate_pool_static
        w.start()
      File "/Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/process.py", line 118, in start
        assert not _current_process._config.get('daemon'), \
    AssertionError: daemonic processes are not allowed to have children
    ... (x 5)
    /Users/alex/.pyenv/versions/3.9.16/lib/python3.9/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 6 leaked semaphore objects to clean up at shutdown                                                                                
      warnings.warn('resource_tracker: There appear to be %d '
    ``` 
  - After fix, nothing is printed:
    ```
    (.venv) $ python -m test_firebase_import_and_dont_use
    (.venv) $
    ```

## Launch
Steps: Merge, Monitor

## Checklist
| Task                                       | Status |
| --------------------------- | ----- |
| Export API                             | N/A    |
| Tested on web and mweb    | N/A      |
| Tested on iOS and Android  | N/A    |